### PR TITLE
Modlist attachment for /zeus-upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The project uses semantic versioning (see [semver](https://semver.org)).
 
 - `/zeus-upload` command now accepts an optional modlist (JSON snippet exported
   from Mod Presets menu in Reforger).
+- Command line flag `--debug` for enabling more verbose debug logging.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The project uses semantic versioning (see [semver](https://semver.org)).
 
 ## [Unreleased]
 
+### Added
+
+- `/zeus-upload` command now accepts an optional modlist (JSON snippet exported
+  from Mod Presets menu in Reforger).
+
 ### Fixed
 
 - Uploaded missions are now pretty-printed, to make it reviewable.

--- a/src/zeusops_bot/cli.py
+++ b/src/zeusops_bot/cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from zeusops_bot import reforger_config_gen as cmd
 from zeusops_bot.discord import ZeusopsBot
 from zeusops_bot.errors import ZeusopsBotConfigException
+from zeusops_bot.logging import setup_logging
 from zeusops_bot.models import ModDetail
 from zeusops_bot.settings import ZeusopsBotConfig, load
 
@@ -35,6 +36,11 @@ def parse_arguments(args: list[str]) -> argparse.Namespace:
         "zeusops-bot",
         description="Multipurpose discord bot for the Zeusops community",
     )
+    parser.add_argument(
+        "--debug",
+        help="Enable debug logging",
+        action="store_true",
+    )
     return parser.parse_args(args)
 
 
@@ -43,10 +49,10 @@ def cli(arguments: list[str] | None = None):
     if arguments is None:
         arguments = sys.argv[1:]
     _args = parse_arguments(arguments)
-    return main()
+    return main(_args.debug)
 
 
-def main():
+def main(debug: bool = False):
     """Run the main bot"""
     try:
         config = load(ZeusopsBotConfig)
@@ -60,11 +66,9 @@ def main():
         print("Error while loading the bot's config from envvars", file=sys.stderr)
         raise
 
-    logging.basicConfig(level=logging.DEBUG)
-    logging.getLogger("discord").setLevel(logging.INFO)
-    logging.getLogger("discord.gateway").setLevel(logging.WARNING)
+    setup_logging(debug)
 
-    bot = ZeusopsBot(config, logging.getLogger("discord"))
+    bot = ZeusopsBot(config, logging.getLogger("zeusops.discord"))
     bot.run()  # Token is already in config
 
 

--- a/src/zeusops_bot/discord.py
+++ b/src/zeusops_bot/discord.py
@@ -1,5 +1,7 @@
 """Manage the Discord-side horrors"""
 
+from logging import Logger
+
 from discord import Bot
 
 from zeusops_bot.cogs import ZeusUpload
@@ -9,7 +11,7 @@ from zeusops_bot.settings import ZeusopsBotConfig
 class ZeusopsBot(Bot):
     """A Discord Client for general purposes"""
 
-    def __init__(self, config: ZeusopsBotConfig, logger, *args, **kwargs):
+    def __init__(self, config: ZeusopsBotConfig, logger: Logger, *args, **kwargs):
         """Initialize the Client"""
         super().__init__(*args, **kwargs)
         self.config = config

--- a/src/zeusops_bot/logging.py
+++ b/src/zeusops_bot/logging.py
@@ -1,0 +1,16 @@
+"""Logging-related utilities"""
+
+import logging
+
+
+def setup_logging(debug):
+    """Set up basic logger"""
+    if debug:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+        # By default the Discord library is very verbose, so we're limiting it
+        # a bit
+        logging.getLogger("discord").setLevel(logging.INFO)
+        logging.getLogger("discord.gateway").setLevel(logging.WARNING)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -10,11 +10,33 @@ from zeusops_bot.reforger_config_gen import ReforgerConfigGenerator
 
 BASE_CONFIG: ConfigFile = {"game": {"scenarioId": "old-value", "mods": []}}
 
-MODLIST: list[ModDetail] = [
+MODLIST_DICT: list[ModDetail] = [
     {"modId": "595F2BF2F44836FB", "name": "RHS - Status Quo", "version": "0.10.4075"},
     {"modId": "5EB744C5F42E0800", "name": "ACE Chopping", "version": "1.2.0"},
     {"modId": "60EAEA0389DB3CC2", "name": "ACE Trenches", "version": "1.2.0"},
 ]
+
+# NOTE: These two formats are not 100% equivalent: Reforger exports the mods in
+# a JSON list, but doesn't actually include the outer [] in the exported
+# string, because the data is meant to be pasted directly inside the
+# `"mods": [ ]` entry of the config file.
+MODLIST_JSON: str = """
+    {
+        "modId": "595F2BF2F44836FB",
+        "name": "RHS - Status Quo",
+        "version": "0.10.4075"
+    },
+    {
+        "modId": "5EB744C5F42E0800",
+        "name": "ACE Chopping",
+        "version": "1.2.0"
+    },
+    {
+        "modId": "60EAEA0389DB3CC2",
+        "name": "ACE Trenches",
+        "version": "1.2.0"
+    }
+"""
 
 
 @pytest.fixture


### PR DESCRIPTION
Add an optional Discord attachment parameter to the /zeus-upload cmd.

Reads the partial JSON export from Reforger, converts into valid JSON, loads as JSON, validates type as ModDetail[] (using pydantic TypeAdapter[1]), and passes it to the reforger class as expected.

Fixes #3.

[1]: https://docs.pydantic.dev/2.10/api/standard_library_types/#typeddict