### PR TITLE
Improve Discord error handling

### DIFF
--- a/src/zeusops_bot/cogs/zeus_upload.py
+++ b/src/zeusops_bot/cogs/zeus_upload.py
@@ -75,3 +75,10 @@ class ZeusUpload(commands.Cog):
             )
         except ConfigFileNotFound as e:
             await ctx.respond(f"Could not find configured mission: {str(e)}")
+
+    @commands.Cog.listener()
+    async def on_application_command_error(
+        self, ctx: discord.ApplicationContext, error: discord.DiscordException
+    ):
+        """Handles application command errors that are not caught elsewhere"""
+        await ctx.respond(f"Unhandled exception: {error}")

--- a/src/zeusops_bot/cogs/zeus_upload.py
+++ b/src/zeusops_bot/cogs/zeus_upload.py
@@ -53,8 +53,11 @@ class ZeusUpload(commands.Cog):
     @commands.slash_command(name="zeus-set-mission")
     async def zeus_set_mission(self, ctx: discord.ApplicationContext, filename: str):
         """Activate the given a mission file as a Zeus"""
-        await ctx.respond(f"Setting mission to {filename=}")
-        self.reforger_confgen.zeus_set_mission(filename)
+        try:
+            self.reforger_confgen.zeus_set_mission(filename)
+            await ctx.respond(f"Setting mission to {filename=}")
+        except ConfigFileNotFound:
+            await ctx.respond(f"Error: could not find mission '{filename}'")
 
     @commands.slash_command(name="zeus-list")
     async def zeus_list(self, ctx: discord.ApplicationContext):


### PR DESCRIPTION
Adds a generic error handler for all unhandled errors from slash commands, as well as a specific one for missing filenames on `/zeus-set-mission`.