### PR TITLE
Reduce test boilerplate with fixtures

### DIFF
--- a/features/reforger_current_mission.feature
+++ b/features/reforger_current_mission.feature
@@ -11,3 +11,9 @@ Scenario: Show currently active mission
   And "mission1.json" is set as the active mission
   When Zeus calls "/current-mission"
   Then "mission1" is displayed
+
+Scenario: Broken mission link produces an error
+  Given "mission1.json" is set as the active mission
+  And file "mission1.json" does not exist in the mission directory
+  When Zeus calls "/current-mission"
+  Then an error about a missing config is raised

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 """Configure tests"""
 
-from tests.fixtures import config_gen, mission_dir
+from tests.fixtures import base_config, mission_dir
 
-__all__ = ["mission_dir", "config_gen"]
+__all__ = ["mission_dir", "base_config"]

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -6,9 +6,15 @@ from pathlib import Path
 import pytest
 
 from zeusops_bot.models import ConfigFile, ModDetail
-from zeusops_bot.reforger_config_gen import ReforgerConfigGenerator
 
-BASE_CONFIG: ConfigFile = {"game": {"scenarioId": "old-value", "mods": []}}
+BASE_CONFIG: ConfigFile = {
+    "game": {
+        "scenarioId": "old-value",
+        "mods": [
+            {"modId": "5EB744C5F42E0800", "name": "ACE Chopping", "version": "1.2.0"}
+        ],
+    }
+}
 
 MODLIST_DICT: list[ModDetail] = [
     {"modId": "595F2BF2F44836FB", "name": "RHS - Status Quo", "version": "0.10.4075"},
@@ -48,11 +54,8 @@ def mission_dir(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def config_gen(tmp_path: Path, mission_dir: Path) -> ReforgerConfigGenerator:
+def base_config(tmp_path: Path) -> Path:
     """Reforger config generator"""
     source_file = tmp_path / "source.json"
     source_file.write_text(json.dumps(BASE_CONFIG))
-    gen = ReforgerConfigGenerator(
-        base_config_file=source_file, target_folder=mission_dir
-    )
-    return gen
+    return source_file

--- a/tests/test_current_mission.py
+++ b/tests/test_current_mission.py
@@ -14,11 +14,14 @@ from zeusops_bot.errors import ConfigFileNotFound
 from zeusops_bot.reforger_config_gen import ReforgerConfigGenerator, as_config_file
 
 
-def test_current_mission(mission_dir: Path, config_gen: ReforgerConfigGenerator):
+def test_current_mission(mission_dir: Path, base_config: Path):
     """Scenario: Show currently active mission"""
     # Given file "mission1.json" exists in the mission directory
     mission_name = "mission1"
     as_config_file(mission_dir, mission_name).touch()
+    config_gen = ReforgerConfigGenerator(
+        base_config_file=base_config, target_folder=mission_dir
+    )
 
     # And "mission1.json" is set as the active mission
     config_gen.zeus_set_mission(mission_name)
@@ -28,13 +31,21 @@ def test_current_mission(mission_dir: Path, config_gen: ReforgerConfigGenerator)
     assert result == mission_name, "Should match previously set mission name"
 
 
-def test_broken_link(mission_dir: Path, config_gen: ReforgerConfigGenerator):
-    """Test that a broken link as active mission raises an error"""
+def test_broken_link(mission_dir: Path, base_config: Path):
+    """Scenario: Broken mission link produces an error"""
+    # Given "mission1.json" is set as the active mission
     mission_name = "mission1"
     config_file = as_config_file(mission_dir, mission_name)
     config_file.touch()
 
+    config_gen = ReforgerConfigGenerator(
+        base_config_file=base_config, target_folder=mission_dir
+    )
     config_gen.zeus_set_mission(mission_name)
+
+    # And file "mission1.json" does not exist in the mission directory
     config_file.unlink()
+    # When Zeus calls "/current-mission"
     with pytest.raises(ConfigFileNotFound):
         config_gen.current_mission()
+    # Then an error about a missing config is raised

--- a/tests/test_list_missions.py
+++ b/tests/test_list_missions.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from zeusops_bot.reforger_config_gen import ReforgerConfigGenerator
+from zeusops_bot.reforger_config_gen import ReforgerConfigGenerator, as_config_file
 
 
 @pytest.mark.parametrize(
@@ -27,15 +27,18 @@ from zeusops_bot.reforger_config_gen import ReforgerConfigGenerator
     ids=["two missions", "empty", "non-json extra"],
 )
 def test_list_missions(
+    base_config: Path,
     mission_dir: Path,
-    config_gen: ReforgerConfigGenerator,
     filenames: list[str],
     mission_names: list[str],
 ):
     """Scenario: List uploaded missions"""
     # Given files "mission1.json" and "mission2.json" exist in the mission directory
     for filename in filenames:
-        (mission_dir / filename).with_suffix(".json").touch()
+        as_config_file(mission_dir, filename).touch()
+    config_gen = ReforgerConfigGenerator(
+        base_config_file=base_config, target_folder=mission_dir
+    )
     # When Zeus calls "/zeus-list"
     result: list[str] = config_gen.list_missions()
     # Then a list of mission names is returned

--- a/tests/test_set_mission.py
+++ b/tests/test_set_mission.py
@@ -1,58 +1,53 @@
 """Validate the set-mission command"""
 
 import json
+from pathlib import Path
 
 from tests.fixtures import BASE_CONFIG
 from zeusops_bot.reforger_config_gen import ReforgerConfigGenerator, as_config_file
 
 
-def test_load_mission(tmp_path):
+def test_load_mission(base_config: Path, mission_dir: Path):
     """Scenario: Load mission from previous upload"""
     # Given a Zeusops mission was uploaded already under <filename>
-    config_base = tmp_path / "reforger_configs"
     filename = "Jib_20250228"
-    uploaded_conf_path = as_config_file(config_base, filename)
-    uploaded_conf_path.parent.mkdir(parents=True, exist_ok=True)
-    gen = ReforgerConfigGenerator(
-        base_config_file=uploaded_conf_path, target_folder=config_base
-    )
+    uploaded_conf_path = as_config_file(mission_dir, filename)
     uploaded_conf_path.write_text(json.dumps(BASE_CONFIG))
+    config_gen = ReforgerConfigGenerator(
+        base_config_file=base_config, target_folder=mission_dir
+    )
     # When Zeus calls "/zeus-set-mission" with <filename>
-    base_conf = tmp_path / "base.json"
-    base_conf.write_text(json.dumps(BASE_CONFIG))
-    gen.zeus_set_mission(filename)
+    config_gen.zeus_set_mission(filename)
     # Then a symbolic link is created from "current-config.json" to <filename>
-    target = config_base / "current-config.json"
+    target = mission_dir / "current-config.json"
     assert target.exists(), "Should have created latest config symlink"
     assert target.is_symlink(), "Target config should be a symlink"
     assert target.readlink() == uploaded_conf_path.relative_to(
-        config_base
+        mission_dir
     ), "Target should point to uploaded file"
 
 
-def test_load_mission_twice(tmp_path):
+def test_load_mission_twice(base_config: Path, mission_dir: Path):
     """Scenario: Load two missions back to back"""
     # Given a Zeusops mission was uploaded already under <filename>
-    config_base = tmp_path / "reforger_configs"
     filename = "Jib_20250228"
-    uploaded_conf_path = as_config_file(config_base, filename)
-    uploaded_conf_path.parent.mkdir(parents=True, exist_ok=True)
-    gen = ReforgerConfigGenerator(
-        base_config_file=uploaded_conf_path, target_folder=config_base
-    )
+    uploaded_conf_path = as_config_file(mission_dir, filename)
     uploaded_conf_path.write_text(json.dumps(BASE_CONFIG))
+    config_gen = ReforgerConfigGenerator(
+        base_config_file=base_config, target_folder=mission_dir
+    )
     # And another Zeusops mission was uploaded already under <filename2>
     filename2 = "Jib_20250229"
-    uploaded_conf_path2 = as_config_file(config_base, filename2)
+    uploaded_conf_path2 = as_config_file(mission_dir, filename2)
     uploaded_conf_path2.write_text(json.dumps(BASE_CONFIG))
     # And Zeus has already called "/zeus-set-mission" with <filename>
-    gen.zeus_set_mission(filename)
+    config_gen.zeus_set_mission(filename)
     # When Zeus calls "/zeus-set-mission" with <filename2>
-    gen.zeus_set_mission(filename2)
+    config_gen.zeus_set_mission(filename2)
     # Then a symbolic link is created from "current-config.json" to <filename2>
-    target = config_base / "current-config.json"
+    target = mission_dir / "current-config.json"
     assert target.exists(), "Should have created latest config symlink"
     assert target.is_symlink(), "Target config should be a symlink"
     assert target.readlink() == uploaded_conf_path2.relative_to(
-        config_base
+        mission_dir
     ), "Target should point to latest mission set"

--- a/tests/test_upload_mission.py
+++ b/tests/test_upload_mission.py
@@ -7,24 +7,24 @@ Feature: Upload mission
 """
 
 import json
+from pathlib import Path
 
 from tests.fixtures import BASE_CONFIG, MODLIST_DICT, MODLIST_JSON
 from zeusops_bot.reforger_config_gen import ReforgerConfigGenerator, extract_mods
 
 
-def test_upload_edits_files(tmp_path):
+def test_upload_edits_files(base_config: Path, mission_dir: Path):
     """Scenario: Upload next mission creates file"""
     # Given a Zeusops mission locally ready
     # And Zeus specifies <modlist.json>, <scenarioId>, <filename>
     scenario_id = "cool-scenario-1"
     filename = "Jib_20250228"
-    dest = tmp_path / "data"
-    source_file = tmp_path / "source.json"
-    source_file.write_text(json.dumps(BASE_CONFIG))
-    gen = ReforgerConfigGenerator(base_config_file=source_file, target_folder=dest)
+    config_gen = ReforgerConfigGenerator(
+        base_config_file=base_config, target_folder=mission_dir
+    )
     # When Zeus calls "/zeus-upload"
     modlist = extract_mods(MODLIST_JSON)
-    out_path = gen.zeus_upload(scenario_id, filename, modlist)
+    out_path = config_gen.zeus_upload(scenario_id, filename, modlist)
     # Then a new server config file is created
     assert out_path.is_file(), "Should have generated a file on disk"
     # And the config file is patched with <modlist.json> and <scenarioId>
@@ -34,18 +34,19 @@ def test_upload_edits_files(tmp_path):
     assert config["game"]["mods"][0] == MODLIST_DICT[0]
 
 
-def test_upload_edits_files_without_modlist(tmp_path):
+def test_upload_edits_files_without_modlist(base_config: Path, mission_dir: Path):
     """Scenario: Upload next mission without modlist"""
     # Given a Zeusops mission locally ready
     # And Zeus specifies <scenarioId>, <filename>
     scenario_id = "cool-scenario-1"
     filename = "Jib_20250228"
-    dest = tmp_path / "data"
-    source_file = tmp_path / "source.json"
-    source_file.write_text(json.dumps(BASE_CONFIG))
-    gen = ReforgerConfigGenerator(base_config_file=source_file, target_folder=dest)
+    config_gen = ReforgerConfigGenerator(
+        base_config_file=base_config, target_folder=mission_dir
+    )
     # When Zeus calls "/zeus-upload"
-    out_path = gen.zeus_upload(scenario_id=scenario_id, filename=filename, modlist=None)
+    out_path = config_gen.zeus_upload(
+        scenario_id=scenario_id, filename=filename, modlist=None
+    )
     # Then a new server config file is created
     assert out_path.is_file(), "Should have generated a file on disk"
     # And the config file is patched with just <scenarioId>


### PR DESCRIPTION
Refactored all existing tests to use the `mission_dir` and `config_gen` fixtures to remove some of the duplicated test code. Additionally added an actual mod in `BASE_CONFIG.game.mods`, so that we're not just checking against an empty list.