### PR TITLE
Add an optional flag to activate a mission config during upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The project uses semantic versioning (see [semver](https://semver.org)).
 
 ## [Unreleased]
 
+### Added
+
+- New optional argument `activate` to `/zeus-upload`. If set to true, the
+  uploaded mission is automatically set as the active config.
+
 ## v0.5.0 - 2025-03-26
 
 ### Added

--- a/features/reforger_upload.feature
+++ b/features/reforger_upload.feature
@@ -14,6 +14,11 @@ Scenario: Upload next mission
   Then a new server config file is created
   And the config file is patched with <modlist.json> and <scenarioId>
 
+Scenario: Upload next mission and activate
+  Given a Zeusops mission locally ready
+  When Zeus calls "/zeus-upload" with the activate flag
+  Then the server config file is set as the active mission
+
 Scenario: Upload next mission without modlist
   Given a Zeusops mission locally ready
   When Zeus calls "/zeus-upload"

--- a/src/zeusops_bot/cogs/zeus_upload.py
+++ b/src/zeusops_bot/cogs/zeus_upload.py
@@ -46,12 +46,18 @@ class ZeusUpload(commands.Cog):
         input_type=discord.SlashCommandOptionType.attachment,
         required=False,
     )
+    @discord.option(
+        "activate",
+        description="Immediately use this uploaded mission as the active mission",
+        required=False,
+    )
     async def zeus_upload(
         self,
         ctx: discord.ApplicationContext,
         scenario_id: str,
         filename: str,
         modlist: discord.Attachment | None = None,
+        activate: bool = False,
     ):
         """Upload a mission as a Zeus"""
         extracted_mods = None
@@ -78,7 +84,7 @@ class ZeusUpload(commands.Cog):
             return
         try:
             path = self.reforger_confgen.zeus_upload(
-                scenario_id, filename, modlist=extracted_mods
+                scenario_id, filename, modlist=extracted_mods, activate=activate
             )
         except ConfigFileNotFound:
             await ctx.respond(

--- a/src/zeusops_bot/reforger_config_gen.py
+++ b/src/zeusops_bot/reforger_config_gen.py
@@ -38,6 +38,7 @@ class ReforgerConfigGenerator:
         scenario_id: str,
         filename: str,
         modlist: list[ModDetail] | None,
+        activate: bool = False,
     ) -> Path:
         """Convert a modlist+scenario into a file on server at given path
 
@@ -45,6 +46,8 @@ class ReforgerConfigGenerator:
           scenario_id: The scenarioID to load within the modlist (selects mission)
           filename: The filename to store the resulting file under
           modlist: The exhaustive list of mods to load, or None to mean no change needed
+          activate: If set to true, the added config is immediately set as the
+                    currently active config
 
         Returns:
           Path: Path to the file generated on filesystem, under {py:attr}`target_folder`

--- a/src/zeusops_bot/reforger_config_gen.py
+++ b/src/zeusops_bot/reforger_config_gen.py
@@ -71,6 +71,8 @@ class ReforgerConfigGenerator:
         target_filepath = as_config_file(self.target_dest, filename)
         # Create the file itself
         target_filepath.write_text(json.dumps(modded_config_dict, indent=4))
+        if activate:
+            self.zeus_set_mission(target_filepath)
         return target_filepath
 
     def zeus_set_mission(self, filename):

--- a/tests/test_upload_mission.py
+++ b/tests/test_upload_mission.py
@@ -9,11 +9,14 @@ Feature: Upload mission
 import json
 from pathlib import Path
 
+import pytest
+
 from tests.fixtures import BASE_CONFIG, MODLIST_DICT, MODLIST_JSON
 from zeusops_bot.reforger_config_gen import ReforgerConfigGenerator, extract_mods
 
 
-def test_upload_edits_files(base_config: Path, mission_dir: Path):
+@pytest.mark.parametrize("activate", (False, True))
+def test_upload_edits_files(base_config: Path, mission_dir: Path, activate: bool):
     """Scenario: Upload next mission creates file"""
     # Given a Zeusops mission locally ready
     # And Zeus specifies <modlist.json>, <scenarioId>, <filename>
@@ -24,7 +27,7 @@ def test_upload_edits_files(base_config: Path, mission_dir: Path):
     )
     # When Zeus calls "/zeus-upload"
     modlist = extract_mods(MODLIST_JSON)
-    out_path = config_gen.zeus_upload(scenario_id, filename, modlist)
+    out_path = config_gen.zeus_upload(scenario_id, filename, modlist, activate)
     # Then a new server config file is created
     assert out_path.is_file(), "Should have generated a file on disk"
     # And the config file is patched with <modlist.json> and <scenarioId>
@@ -32,6 +35,25 @@ def test_upload_edits_files(base_config: Path, mission_dir: Path):
     assert config["game"]["scenarioId"] == scenario_id, "Should update scenarioId"
     assert isinstance(config["game"]["mods"], list)
     assert config["game"]["mods"][0] == MODLIST_DICT[0]
+
+
+@pytest.mark.xfail(reason="Not implemented")
+def test_upload_activate_mission(base_config: Path, mission_dir: Path):
+    """Scenario: Upload next mission and activate"""
+    # Given a Zeusops mission locally ready
+    # When Zeus calls "/zeus-upload" with the activate flag
+    config_gen = ReforgerConfigGenerator(
+        base_config_file=base_config, target_folder=mission_dir
+    )
+    modlist = extract_mods(MODLIST_JSON)
+    out_path = config_gen.zeus_upload(
+        "cool-scenario-1", "Jib_20250228", modlist, activate=True
+    )
+    # Then the server config file is set as the active mission
+    target = mission_dir / "current-config.json"
+    assert target.readlink() == out_path.relative_to(
+        mission_dir
+    ), "Target should point to uploaded file"
 
 
 def test_upload_edits_files_without_modlist(base_config: Path, mission_dir: Path):

--- a/tests/test_upload_mission.py
+++ b/tests/test_upload_mission.py
@@ -37,7 +37,6 @@ def test_upload_edits_files(base_config: Path, mission_dir: Path, activate: bool
     assert config["game"]["mods"][0] == MODLIST_DICT[0]
 
 
-@pytest.mark.xfail(reason="Not implemented")
 def test_upload_activate_mission(base_config: Path, mission_dir: Path):
     """Scenario: Upload next mission and activate"""
     # Given a Zeusops mission locally ready


### PR DESCRIPTION
Fixes #14. Split across several commits, but can be squashed.

I'm *slightly* hesitant to add the new flag to `zeus_upload()`, because activating a config isn't really the job of the upload function. But again, I don't want to make that a responsibility of the Discord glue either, and an `upload_and_potentially_activate()` wouldn't really make sense to me either.