### PR TITLE
Automatically remove version numbers from uploaded modlists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The project uses semantic versioning (see [semver](https://semver.org)).
 
 - New optional argument `activate` to `/zeus-upload`. If set to true, the
   uploaded mission is automatically set as the active config.
+- Version numbers are automatically removed from the uploaded modlist. A new
+  optional argument `keep_versions=False` for `/zeus-upload` can be used to
+  preserve the version numbers.
 
 ## v0.5.0 - 2025-03-26
 

--- a/features/reforger_upload.feature
+++ b/features/reforger_upload.feature
@@ -13,6 +13,14 @@ Scenario: Upload next mission
   And Zeus specifies <modlist.json>, <scenarioId>, <filename>
   Then a new server config file is created
   And the config file is patched with <modlist.json> and <scenarioId>
+  And the version numbers are removed from the mods.
+
+Scenario: Upload next mission with versions retained
+  Given a Zeusops mission locally ready
+  When Zeus calls "/zeus-upload" with "keep_versions=True"
+  Then a new server config file is created
+  And the config file is patched with <modlist.json> and <scenarioId>
+  And the version numbers are kept as-is.
 
 Scenario: Upload next mission and activate
   Given a Zeusops mission locally ready

--- a/src/zeusops_bot/cogs/zeus_upload.py
+++ b/src/zeusops_bot/cogs/zeus_upload.py
@@ -51,6 +51,13 @@ class ZeusUpload(commands.Cog):
         description="Immediately use this uploaded mission as the active mission",
         required=False,
     )
+    @discord.option(
+        "keep_versions",
+        description=(
+            "Prevent version numbers from being removed from the uploaded modlist"
+        ),
+        required=False,
+    )
     async def zeus_upload(
         self,
         ctx: discord.ApplicationContext,
@@ -58,13 +65,16 @@ class ZeusUpload(commands.Cog):
         filename: str,
         modlist: discord.Attachment | None = None,
         activate: bool = False,
+        keep_versions: bool = True,
     ):
         """Upload a mission as a Zeus"""
         extracted_mods = None
         try:
             if modlist is not None:
                 data = await modlist.read()
-                extracted_mods = extract_mods(data.decode())
+                extracted_mods = extract_mods(
+                    data.decode(), keep_versions=keep_versions
+                )
         except ConfigFileInvalidJson as e:
             await ctx.respond(
                 "Failed to understand the attached modlist as JSON. "

--- a/src/zeusops_bot/reforger_config_gen.py
+++ b/src/zeusops_bot/reforger_config_gen.py
@@ -178,7 +178,7 @@ def extract_mods(modlist: str | None, keep_versions=False) -> list[ModDetail] | 
         return None
     modlist = f"[{modlist}]"
     try:
-        return modlist_typeadapter.validate_json(modlist)
+        mods = modlist_typeadapter.validate_json(modlist)
     except ValidationError as e:
         errors = e.errors()
         if len(errors) > 1:
@@ -191,3 +191,9 @@ def extract_mods(modlist: str | None, keep_versions=False) -> list[ModDetail] | 
             case _:
                 # Unknown error
                 raise e
+
+    if not keep_versions:
+        for mod in mods:
+            del mod["version"]
+
+    return mods

--- a/src/zeusops_bot/reforger_config_gen.py
+++ b/src/zeusops_bot/reforger_config_gen.py
@@ -158,13 +158,14 @@ def patch_file(source: dict, modlist: list[ModDetail] | None, scenario_id: str) 
     return mod
 
 
-def extract_mods(modlist: str | None) -> list[ModDetail] | None:
+def extract_mods(modlist: str | None, keep_versions=False) -> list[ModDetail] | None:
     """Extracts a list of ModDetail entries from a mod list exported from Reforger
 
     Args:
       modlist: A partial JSON string of mods to extract. Can be None if the
                user did not provide any mods, in which case the operation is a
                no-op.
+      keep_versions: Preserve mod versions in the extracted list of mods.
 
     Raises:
       pydantic.ValidationError: Generic error in validating the mod list

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -22,6 +22,12 @@ MODLIST_DICT: list[ModDetail] = [
     {"modId": "60EAEA0389DB3CC2", "name": "ACE Trenches", "version": "1.2.0"},
 ]
 
+MODLIST_DICT_VERSIONLESS: list[ModDetail] = [
+    {"modId": "595F2BF2F44836FB", "name": "RHS - Status Quo"},
+    {"modId": "5EB744C5F42E0800", "name": "ACE Chopping"},
+    {"modId": "60EAEA0389DB3CC2", "name": "ACE Trenches"},
+]
+
 # NOTE: These two formats are not 100% equivalent: Reforger exports the mods in
 # a JSON list, but doesn't actually include the outer [] in the exported
 # string, because the data is meant to be pasted directly inside the

--- a/tests/test_upload_mission.py
+++ b/tests/test_upload_mission.py
@@ -23,14 +23,7 @@ from zeusops_bot.reforger_config_gen import ReforgerConfigGenerator, extract_mod
 
 @pytest.mark.parametrize(
     "keep_versions,mods",
-    [
-        (False, MODLIST_DICT),
-        pytest.param(
-            True,
-            MODLIST_DICT_VERSIONLESS,
-            marks=pytest.mark.xfail(reason="Not implemented"),
-        ),
-    ],
+    [(False, MODLIST_DICT_VERSIONLESS), (True, MODLIST_DICT)],
     ids=["strip versions", "keep versions"],
 )
 @pytest.mark.parametrize("activate", (False, True), ids=["no activate", "activate"])


### PR DESCRIPTION
Fixes #15. Several commits, but can be squashed.

Would it be clearer if the logic was flipped and the flag was called `keep_versions` or similar instead, since the default functionality is to remove the versions?