### PR TITLE
Autocomplete mission names mid-word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ The project uses semantic versioning (see [semver](https://semver.org)).
   optional argument `keep_versions=False` for `/zeus-upload` can be used to
   preserve the version numbers.
 
+### Changed
+
+- Autocompletion in `/zeus-set-mission` now matches everywhere in the mission
+  name, not just the beginning. This makes it easier to search based on Zeus
+  name, for example.
+
 ## v0.5.0 - 2025-03-26
 
 ### Added

--- a/src/zeusops_bot/cogs/zeus_upload.py
+++ b/src/zeusops_bot/cogs/zeus_upload.py
@@ -5,7 +5,6 @@ import typing
 import discord
 from discord.commands import option
 from discord.ext import commands
-from discord.utils import basic_autocomplete
 from pydantic import TypeAdapter, ValidationError
 
 if typing.TYPE_CHECKING:
@@ -28,7 +27,11 @@ def _autocomplete_missions(ctx: discord.AutocompleteContext) -> list[str]:
 
     TODO: Return list[discord.OptionChoice] instead?
     """
-    return ctx.bot.reforger_confgen.list_missions()
+    return [
+        mission
+        for mission in ctx.bot.reforger_confgen.list_missions()
+        if ctx.value.lower() in mission.lower()
+    ]
 
 
 class ZeusUpload(commands.Cog):
@@ -121,7 +124,7 @@ class ZeusUpload(commands.Cog):
     @option(
         "filename",
         description="Mission filename",
-        autocomplete=basic_autocomplete(_autocomplete_missions),
+        autocomplete=_autocomplete_missions,
     )
     async def zeus_set_mission(
         self,


### PR DESCRIPTION
Autocompletion in `/zeus-set-mission` now matches everywhere in the mission name, not just the beginning. This makes it easier to search based on Zeus name, for example. Fixes #16.

It turn out that the pycord built-in helper function `basic_autocomplete` only matches the beginning of the word, so had to fall back to custom matching.