### PR TITLE
Autocomplete existing mission names and automatic scenario ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The project uses semantic versioning (see [semver](https://semver.org)).
 
 ## [Unreleased]
 
+### Added
+
+- `/zeus-upload` now autocompletes existing mission filenames.
+
 ## v0.6.0 - 2025-04-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The project uses semantic versioning (see [semver](https://semver.org)).
 ### Added
 
 - `/zeus-upload` now autocompletes existing mission filenames.
+- When updating an existing mission with `/zeus-upload`, the `scenario_id`
+  parameter is optional and will be automatically deduced from the existing
+  mission config.
 
 ## v0.6.0 - 2025-04-06
 

--- a/features/reforger_upload.feature
+++ b/features/reforger_upload.feature
@@ -33,3 +33,15 @@ Scenario: Upload next mission without modlist
   And Zeus specifies <scenarioId>, <filename>
   Then a new server config file is created
   And the config file is patched with just <scenarioId>
+
+Scenario: Update modlist of an existing mission
+  Given a Zeusops mission uploaded previously
+  When Zeus calls "/zeus-upload" with an existing filename
+  And Zeus specifies <modlist.json>
+  Then the scenario ID is deduced automatically from the existing config
+  And the existing config is updated with the new mods.
+
+Scenario: Not providing a scenario ID for a new mission produces an error
+  When Zeus calls "/zeus-upload" with a new filename
+  And Zeus does not specify <scenarioId>
+  Then an error about a missing mission is raised.

--- a/src/zeusops_bot/cli.py
+++ b/src/zeusops_bot/cli.py
@@ -76,8 +76,8 @@ def reforger_upload(
     base_config_file: Path,
     target_folder: Path,
     modlist: list[ModDetail] | None,
-    scenario_id: str,
     filename: str,
+    scenario_id: str | None = None,
 ):
     """Run the program's /zeus-upload command"""
     conf_generator = cmd.ReforgerConfigGenerator(base_config_file, target_folder)
@@ -85,6 +85,6 @@ def reforger_upload(
         print(f"Loading {len(modlist)} mods, for {scenario_id=}...")
     else:
         print(f"Loading {scenario_id=}...")
-    out_path = conf_generator.zeus_upload(scenario_id, filename, modlist)
+    out_path = conf_generator.zeus_upload(filename, scenario_id, modlist)
     print(f"Saved under file {out_path.name}")
     return Exit.SUCCESS

--- a/src/zeusops_bot/cogs/zeus_upload.py
+++ b/src/zeusops_bot/cogs/zeus_upload.py
@@ -22,7 +22,8 @@ modlist_typeadapter = TypeAdapter(list[ModDetail])
 def _autocomplete_missions(ctx: discord.AutocompleteContext) -> list[str]:
     """List known missions
 
-    Used to populate the autocomplete list in /zeus-set-mission.
+    Used to populate the autocomplete list in /zeus-set-mission and
+    /zeus-upload.
 
     TODO: Return list[discord.OptionChoice] instead?
     """
@@ -42,6 +43,13 @@ class ZeusUpload(commands.Cog):
         self.reforger_confgen = reforger_confgen
 
     @commands.slash_command(name="zeus-upload")
+    @discord.option(
+        "filename",
+        description=(
+            "Mission filename. Choose an existing filename to update the mission."
+        ),
+        autocomplete=_autocomplete_missions,
+    )
     @discord.option(
         "modlist",
         description="Modlist JSON exported from Reforger",

--- a/src/zeusops_bot/cogs/zeus_upload.py
+++ b/src/zeusops_bot/cogs/zeus_upload.py
@@ -71,8 +71,8 @@ class ZeusUpload(commands.Cog):
     async def zeus_upload(
         self,
         ctx: discord.ApplicationContext,
-        scenario_id: str,
         filename: str,
+        scenario_id: str,
         modlist: discord.Attachment | None = None,
         activate: bool = False,
         keep_versions: bool = True,
@@ -104,7 +104,7 @@ class ZeusUpload(commands.Cog):
             return
         try:
             path = self.reforger_confgen.zeus_upload(
-                scenario_id, filename, modlist=extracted_mods, activate=activate
+                filename, scenario_id, modlist=extracted_mods, activate=activate
             )
         except ConfigFileNotFound:
             await ctx.respond(

--- a/src/zeusops_bot/cogs/zeus_upload.py
+++ b/src/zeusops_bot/cogs/zeus_upload.py
@@ -51,6 +51,15 @@ class ZeusUpload(commands.Cog):
         autocomplete=_autocomplete_missions,
     )
     @discord.option(
+        "scenario_id",
+        description=(
+            "Workshop ID for the scenario. Not required "
+            "updating an existing mission config"
+        ),
+        input_type=str,
+        required=False,
+    )
+    @discord.option(
         "modlist",
         description="Modlist JSON exported from Reforger",
         input_type=discord.SlashCommandOptionType.attachment,
@@ -72,7 +81,7 @@ class ZeusUpload(commands.Cog):
         self,
         ctx: discord.ApplicationContext,
         filename: str,
-        scenario_id: str,
+        scenario_id: str | None = None,
         modlist: discord.Attachment | None = None,
         activate: bool = False,
         keep_versions: bool = True,
@@ -106,11 +115,8 @@ class ZeusUpload(commands.Cog):
             path = self.reforger_confgen.zeus_upload(
                 filename, scenario_id, modlist=extracted_mods, activate=activate
             )
-        except ConfigFileNotFound:
-            await ctx.respond(
-                "Bot config error: the base config file could not be found"
-                f" Tell the Techmins! Path was: {self.reforger_confgen.base_config}"
-            )
+        except ConfigFileNotFound as e:
+            await ctx.respond(f"Config file not found. Error was: \n ```\n{e}\n```")
             return
         except ConfigFileInvalidJson as e:
             await ctx.respond(

--- a/src/zeusops_bot/models.py
+++ b/src/zeusops_bot/models.py
@@ -2,6 +2,8 @@
 
 from typing import NotRequired, TypedDict
 
+from pydantic import TypeAdapter
+
 
 class ModDetail(TypedDict):
     """A single mod's details
@@ -26,3 +28,23 @@ class ConfigFile(TypedDict):
     """The reforger config file"""
 
     game: ConfigFileGameSection
+
+
+class TypedTypeAdapter[T]:
+    """A wrapper around Pydantic's TypeAdapter to make mypy happy
+
+    This class defines basically the same types as the actual TypeAdapter, but
+    somehow mypy doesn't complain when using this one.
+    """
+
+    def __init__(self, type: type[T], **kwargs) -> None:
+        """Typed init"""
+        self.adapter = TypeAdapter(type, *kwargs)
+
+    def validate_json(self, data: str | bytes | bytearray, /, **kwargs) -> T:
+        """Typed method"""
+        return self.adapter.validate_json(data, *kwargs)
+
+
+modlist_typeadapter = TypedTypeAdapter(list[ModDetail])
+configfile_typeadapter = TypedTypeAdapter(ConfigFile)

--- a/src/zeusops_bot/reforger_config_gen.py
+++ b/src/zeusops_bot/reforger_config_gen.py
@@ -35,19 +35,21 @@ class ReforgerConfigGenerator:
 
     def zeus_upload(
         self,
-        scenario_id: str,
         filename: str,
-        modlist: list[ModDetail] | None,
+        scenario_id: str | None = None,
+        modlist: list[ModDetail] | None = None,
         activate: bool = False,
     ) -> Path:
         """Convert a modlist+scenario into a file on server at given path
 
         Args:
-          scenario_id: The scenarioID to load within the modlist (selects mission)
           filename: The filename to store the resulting file under
+          scenario_id: The scenarioID to load within the modlist (selects
+                mission). If set to None, will be automatically fetched from the
+                file based on the filename.
           modlist: The exhaustive list of mods to load, or None to mean no change needed
           activate: If set to true, the added config is immediately set as the
-                    currently active config
+                currently active config
 
         Returns:
           Path: Path to the file generated on filesystem, under {py:attr}`target_folder`
@@ -58,6 +60,8 @@ class ReforgerConfigGenerator:
           ConfigPatchingError: Patching of the file failed, sending lib exception as arg
 
         """
+        if scenario_id is None:
+            raise NotImplementedError
         # Ensure parent folder exists
         self.target_dest.mkdir(parents=True, exist_ok=True)
         # Read the original config file

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -16,13 +16,13 @@ BASE_CONFIG: ConfigFile = {
     }
 }
 
-MODLIST_DICT: list[ModDetail] = [
+MODLIST_DICTS: list[ModDetail] = [
     {"modId": "595F2BF2F44836FB", "name": "RHS - Status Quo", "version": "0.10.4075"},
     {"modId": "5EB744C5F42E0800", "name": "ACE Chopping", "version": "1.2.0"},
     {"modId": "60EAEA0389DB3CC2", "name": "ACE Trenches", "version": "1.2.0"},
 ]
 
-MODLIST_DICT_VERSIONLESS: list[ModDetail] = [
+MODLIST_DICTS_VERSIONLESS: list[ModDetail] = [
     {"modId": "595F2BF2F44836FB", "name": "RHS - Status Quo"},
     {"modId": "5EB744C5F42E0800", "name": "ACE Chopping"},
     {"modId": "60EAEA0389DB3CC2", "name": "ACE Trenches"},

--- a/tests/test_set_mission.py
+++ b/tests/test_set_mission.py
@@ -22,9 +22,9 @@ def test_load_mission(base_config: Path, mission_dir: Path):
     target = mission_dir / "current-config.json"
     assert target.exists(), "Should have created latest config symlink"
     assert target.is_symlink(), "Target config should be a symlink"
-    assert target.readlink() == uploaded_conf_path.relative_to(
-        mission_dir
-    ), "Target should point to uploaded file"
+    assert target.readlink() == uploaded_conf_path.relative_to(mission_dir), (
+        "Target should point to uploaded file"
+    )
 
 
 def test_load_mission_twice(base_config: Path, mission_dir: Path):
@@ -48,6 +48,6 @@ def test_load_mission_twice(base_config: Path, mission_dir: Path):
     target = mission_dir / "current-config.json"
     assert target.exists(), "Should have created latest config symlink"
     assert target.is_symlink(), "Target config should be a symlink"
-    assert target.readlink() == uploaded_conf_path2.relative_to(
-        mission_dir
-    ), "Target should point to latest mission set"
+    assert target.readlink() == uploaded_conf_path2.relative_to(mission_dir), (
+        "Target should point to latest mission set"
+    )

--- a/tests/test_upload_mission.py
+++ b/tests/test_upload_mission.py
@@ -68,9 +68,9 @@ def test_upload_activate_mission(base_config: Path, mission_dir: Path):
     )
     # Then the server config file is set as the active mission
     target = mission_dir / "current-config.json"
-    assert target.readlink() == out_path.relative_to(
-        mission_dir
-    ), "Target should point to uploaded file"
+    assert target.readlink() == out_path.relative_to(mission_dir), (
+        "Target should point to uploaded file"
+    )
 
 
 def test_upload_edits_files_without_modlist(base_config: Path, mission_dir: Path):
@@ -93,7 +93,6 @@ def test_upload_edits_files_without_modlist(base_config: Path, mission_dir: Path
     assert config["game"]["mods"] == BASE_CONFIG["game"]["mods"], "Should keep modlist"
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
 def test_upload_existing_filename_without_scenarioid(
     base_config: Path, mission_dir: Path
 ):
@@ -118,7 +117,6 @@ def test_upload_existing_filename_without_scenarioid(
     assert config["game"]["mods"] == MODLIST_DICTS, "Should update modlist"
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
 def test_upload_no_scenarioid_without_file_fails(base_config: Path, mission_dir: Path):
     """Scenario: Not providing a scenario ID for a new mission produces an error"""
     # When Zeus calls "/zeus-upload" with a new filename

--- a/tests/test_upload_mission.py
+++ b/tests/test_upload_mission.py
@@ -13,17 +13,18 @@ import pytest
 
 from tests.fixtures import (
     BASE_CONFIG,
-    MODLIST_DICT,
-    MODLIST_DICT_VERSIONLESS,
+    MODLIST_DICTS,
+    MODLIST_DICTS_VERSIONLESS,
     MODLIST_JSON,
 )
+from zeusops_bot.errors import ConfigFileNotFound
 from zeusops_bot.models import ModDetail
 from zeusops_bot.reforger_config_gen import ReforgerConfigGenerator, extract_mods
 
 
 @pytest.mark.parametrize(
     "keep_versions,mods",
-    [(False, MODLIST_DICT_VERSIONLESS), (True, MODLIST_DICT)],
+    [(False, MODLIST_DICTS_VERSIONLESS), (True, MODLIST_DICTS)],
     ids=["strip versions", "keep versions"],
 )
 @pytest.mark.parametrize("activate", (False, True), ids=["no activate", "activate"])
@@ -44,7 +45,7 @@ def test_upload_edits_files(
     )
     # When Zeus calls "/zeus-upload"
     modlist = extract_mods(MODLIST_JSON, keep_versions)
-    out_path = config_gen.zeus_upload(scenario_id, filename, modlist, activate)
+    out_path = config_gen.zeus_upload(filename, scenario_id, modlist, activate)
     # Then a new server config file is created
     assert out_path.is_file(), "Should have generated a file on disk"
     # And the config file is patched with <modlist.json> and <scenarioId>
@@ -63,7 +64,7 @@ def test_upload_activate_mission(base_config: Path, mission_dir: Path):
     )
     modlist = extract_mods(MODLIST_JSON)
     out_path = config_gen.zeus_upload(
-        "cool-scenario-1", "Jib_20250228", modlist, activate=True
+        "Jib_20250228", "cool-scenario-1", modlist, activate=True
     )
     # Then the server config file is set as the active mission
     target = mission_dir / "current-config.json"
@@ -82,9 +83,7 @@ def test_upload_edits_files_without_modlist(base_config: Path, mission_dir: Path
         base_config_file=base_config, target_folder=mission_dir
     )
     # When Zeus calls "/zeus-upload"
-    out_path = config_gen.zeus_upload(
-        scenario_id=scenario_id, filename=filename, modlist=None
-    )
+    out_path = config_gen.zeus_upload(filename, scenario_id, modlist=None)
     # Then a new server config file is created
     assert out_path.is_file(), "Should have generated a file on disk"
     # And the config file is patched with just <scenarioId>
@@ -92,3 +91,42 @@ def test_upload_edits_files_without_modlist(base_config: Path, mission_dir: Path
     assert config["game"]["scenarioId"] == scenario_id, "Should update scenarioId"
     assert isinstance(config["game"]["mods"], list)
     assert config["game"]["mods"] == BASE_CONFIG["game"]["mods"], "Should keep modlist"
+
+
+@pytest.mark.xfail(raises=NotImplementedError)
+def test_upload_existing_filename_without_scenarioid(
+    base_config: Path, mission_dir: Path
+):
+    """Scenario: Update modlist of an existing mission"""
+    # Given a Zeusops mission uploaded previously
+    scenario_id = "cool-scenario-1"
+    filename = "Jib_20250228"
+    config_gen = ReforgerConfigGenerator(
+        base_config_file=base_config, target_folder=mission_dir
+    )
+    # When Zeus calls "/zeus-upload"
+    modlist = MODLIST_DICTS[0:-1]
+    out_path = config_gen.zeus_upload(filename, scenario_id, modlist)
+    # When Zeus calls "/zeus-upload" with an existing filename
+    # And Zeus specifies <modlist.json>
+    out_path = config_gen.zeus_upload(filename, scenario_id=None, modlist=MODLIST_DICTS)
+    # Then the scenario ID is deduced automatically from the existing config
+    config = json.loads(out_path.read_text())
+    assert config["game"]["scenarioId"] == scenario_id, "Should use existing scenarioId"
+    # And the existing config is updated with the new mods.
+    assert isinstance(config["game"]["mods"], list)
+    assert config["game"]["mods"] == MODLIST_DICTS, "Should update modlist"
+
+
+@pytest.mark.xfail(raises=NotImplementedError)
+def test_upload_no_scenarioid_without_file_fails(base_config: Path, mission_dir: Path):
+    """Scenario: Not providing a scenario ID for a new mission produces an error"""
+    # When Zeus calls "/zeus-upload" with a new filename
+    # And Zeus does not specify <scenarioId>
+    filename = "Jib_20250228"
+    config_gen = ReforgerConfigGenerator(
+        base_config_file=base_config, target_folder=mission_dir
+    )
+    # Then an error about a missing mission is raised.
+    with pytest.raises(ConfigFileNotFound):
+        config_gen.zeus_upload(filename, scenario_id=None, modlist=MODLIST_DICTS)


### PR DESCRIPTION
- `/zeus-upload` now autocompletes existing mission filenames. Fixes #26.
- When updating an existing mission with `/zeus-upload`, the `scenario_id` parameter is optional and will be automatically deduced from the existing mission config. Fixes #27.