### PR TITLE
Build docker images from open PRs

### DIFF
--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -1,11 +1,18 @@
 ---
 name: Publish Docker
 
+# Allow publishing dev images from open PRs
+permissions:
+  packages: write
+
 on:
   push:
+    branches:
+      - main
+  pull_request:
 
 env:
-  IMAGE_TAG: ghcr.io/${{ github.repository_owner }}/zeusops-bot:latest
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/zeusops-bot
 
 jobs:
   build:
@@ -14,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Image
         run: docker build -f release.Dockerfile -t zeusops-bot .
@@ -30,27 +37,31 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  main_publish:
+  publish:
     name: Publish Image
     runs-on: ubuntu-latest
     needs:
       - build
-    if: github.ref == 'refs/heads/main'
     steps:
+      - name: Create Release Image Name
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo "IMAGE_TAG_LOWER=${IMAGE_NAME@L}:latest" >> "${GITHUB_ENV}"
+      - name: Create PR Image Name
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "IMAGE_TAG_LOWER=${IMAGE_NAME@L}:dev-pr-${{ github.event.number }}" >> "${GITHUB_ENV}"
       - name: Login to GHCR
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/download-artifact@v4
         with:
           name: image
       - name: Load Image
         run: docker load < image.tar.gz
-      - name: lowercase repo
-        run: |
-          echo "IMAGE_TAG_LOWER=${IMAGE_TAG@L}" >> "${GITHUB_ENV}"
       - name: Tag Image
         run: docker tag zeusops-bot "$IMAGE_TAG_LOWER"
       - name: Push Image


### PR DESCRIPTION
This automatically builds docker images and pushes them to the registry with a `dev-pr-NUMBER` tag. Makes it possible to deploy PR changes even while the PR is being reviewed.